### PR TITLE
fix: optimize sync.Pool usage to avoid allocation during Put() calls

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,7 +20,10 @@ const (
 )
 
 var serveMsgBuf = sync.Pool{
-	New: func() any { return make([]byte, TCPBufferSize) },
+	New: func() any {
+		buf := make([]byte, TCPBufferSize)
+		return &buf
+	},
 }
 
 var bufUDPPool = sync.Pool{
@@ -136,8 +139,8 @@ func (s *Server) serveTCP(ctx context.Context) error {
 func handleConnection(conn net.Conn) error {
 	defer conn.Close()
 
-	buf := serveMsgBuf.Get().([]byte)
-	defer serveMsgBuf.Put(buf)
+	buf := *serveMsgBuf.Get().(*[]byte)
+	defer serveMsgBuf.Put(&buf)
 
 	for {
 		n, err := conn.Read(buf)


### PR DESCRIPTION
## Summary
- Optimize `serveMsgBuf` sync.Pool to store pointers to byte slices instead of byte slices directly
- Prevents boxing allocations that occur when calling `Put()` with `[]byte` values

## Technical Details
The previous implementation stored `[]byte` directly in the pool, which caused allocations when the slice was boxed into an `interface{}` during `Put()` calls. By storing `*[]byte` instead, we avoid this allocation overhead.

## Test plan
- [x] Verify existing tests still pass
- [x] Manual testing of TCP server functionality
- [ ] Performance benchmarking to confirm allocation reduction

🤖 Generated with [Claude Code](https://claude.ai/code)