### PR TITLE
feat: add --help flag support

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,9 @@ func main() {
 	// Handle version flag
 	handleVersion()
 
+	// Handle help flag
+	handleHelp()
+
 	// Handle listen addresses for server mode
 	if serverMode {
 		// Default listen address if none provided

--- a/version.go
+++ b/version.go
@@ -11,14 +11,23 @@ const version = "0.8.0"
 
 var revision = "HEAD"
 var showVersion bool
+var showHelp bool
 
 func init() {
 	pflag.BoolVar(&showVersion, "version", false, "show version information")
+	pflag.BoolVarP(&showHelp, "help", "h", false, "show help information")
 }
 
 func handleVersion() {
 	if showVersion {
 		fmt.Printf("tcpulse %s (revision: %s)\n", version, revision)
+		os.Exit(0)
+	}
+}
+
+func handleHelp() {
+	if showHelp {
+		printUsage()
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
## Summary
- Add --help/-h flag that displays usage information and exits cleanly
- Follows the same implementation pattern as the existing --version flag

## Test plan
- [x] Verify `--help` displays usage information and exits
- [x] Verify `-h` short form works correctly  
- [x] Confirm existing functionality is unaffected
- [x] Run test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)